### PR TITLE
Fix extras - new attempt

### DIFF
--- a/Contents/Resources/Common/VideoFiles.py
+++ b/Contents/Resources/Common/VideoFiles.py
@@ -10,7 +10,7 @@ ignore_samples = ['[-\._]sample', 'sample[-\._]']
 ignore_trailers = ['-trailer\.']
 ignore_extras = ['^trailer.?$','-deleted\.', '-behindthescenes\.', '-interview\.', '-scene\.']
 ignore_extras_startswith = ['^movie-trailer.*']
-ignore_dirs =  ['extras?', '!?samples?', 'bonus', '.*bonus disc.*', 'bdmv', 'video_ts', '^interview.?$', '^scene.?$', '^trailer.?$', '^deleted.?(scene.?)?$', '^behind.?the.?scenes$']
+ignore_dirs =  ['\\bextras?\\b', '!?samples?', 'bonus', '.*bonus disc.*', 'bdmv', 'video_ts', '^interview.?$', '^scene.?$', '^trailer.?$', '^deleted.?(scene.?)?$', '^behind.?the.?scenes$']
 ignore_suffixes = ['.dvdmedia']
 
 source_dict = {'bluray':['bdrc','bdrip','bluray','bd','brrip','hdrip','hddvd','hddvdrip'],'cam':['cam'],'dvd':['ddc','dvdrip','dvd','r1','r3','r5'],'retail':['retail'],


### PR DESCRIPTION
The \b attempt seems correct - but 1) needs to be at both ends and 2) needs to be escaped in the string.

I tested with the following directory structure:

```
.
|-- Extraction
|   `-- Extraction.mkv
|-- Extraterrestrial.mkv
|-- Hou Hsia Hsien- Cafe Lumiere (2003) [ +extras]
|   |-- Hou Hsia Hsien- Cafe Lumiere (2003).mkv
|   `-- extras
|       `-- Interview with Hou Hsiao-Hsien.avi
`-- The Double Life of Veronique (1991)
    |-- Extras
    |   `-- Alternate U.S. ending.avi
    `-- The Double Life of Veronique (1991).mkv
```

And I got four movies and the extras ignored.