### PR TITLE
Fix for excluding folder with subfolders with non-latin characters on Windows

### DIFF
--- a/Contents/Resources/Common/Filter.py
+++ b/Contents/Resources/Common/Filter.py
@@ -101,7 +101,7 @@ def Scan(path, files, mediaList, subdirs, exts, root=None):
   # Add glob matches from .plexignore before whacking.
   for pattern in plexignore_dirs:
     for match in glob.glob(pattern):
-      if os.path.isdir(match):
+      if os.path.isdir(match.decode("utf-8")):
         dirs_to_whack.append(os.path.dirname(match))
       else:
         files_to_whack.append(match)


### PR DESCRIPTION
It's workaround, tested only at Windows 10 x64.

If _.plexignore_ contains folder with non-latin character, scanner doesn't exclude its subfolders.

Example:
Root dir = D:\test

Content of D:\test\\.plexignore
`и/*`

Folder structure
```
D:\test
   и \ 1 \ 30.mkv
   и \ 20.mkv
   10.mkv
```
Original scanner adds to library: 10.mkv, 30.mkv
Fixed scanned adds only 10.mkv

This is because os.path.isdir() returns false if it encounters Unicode character.
A continuation of example:
```
>>> os.path.isdir("d:\\test\\\xd0\xb8")
False
>>> os.path.isdir("d:\\test\\\xd0\xb8".decode("utf-8"))
True
```